### PR TITLE
Fixed workflow functions path

### DIFF
--- a/.github/workflows/deploy-functions.yaml
+++ b/.github/workflows/deploy-functions.yaml
@@ -10,7 +10,7 @@ on:
 
 env:
   AZURE_FUNCTIONAPP_NAME: 'notification-hub-functions'
-  AZURE_FUNCTIONAPP_PACKAGE_PATH: 'src/apps/NotificationsAndMessaging.Functions'
+  AZURE_FUNCTIONAPP_PACKAGE_PATH: 'src/apps/Functions'
   DOTNET_VERSION: '6.x'
 
 jobs:


### PR DESCRIPTION
Path to the functions app was incorrect in the workflow. It was using the old path.  Paths were changed since the compiler would receive a path to java files that exceeded the MAX_PATH value